### PR TITLE
Standardize scraper models on Pydantic

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data package containing Pydantic models used across the project."""
+
+from . import models
+
+__all__ = ["models"]

--- a/data/models.py
+++ b/data/models.py
@@ -1,0 +1,111 @@
+"""Pydantic models and enumerations shared across the application."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CompanyName(str, Enum):
+    """Enumeration of supported companies."""
+
+    META = "meta"
+    AMAZON = "amazon"
+    APPLE = "apple"
+    NETFLIX = "netflix"
+    GOOGLE = "google"
+
+
+class JobCategory(str, Enum):
+    """Supported job categories for classification."""
+
+    TECHNOLOGY = "technology"
+    DATA = "data"
+    PRODUCT = "product"
+    DESIGN = "design"
+    SALES = "sales"
+    MARKETING = "marketing"
+    OPERATIONS = "operations"
+    FINANCE = "finance"
+    HR = "hr"
+    LEGAL = "legal"
+    CUSTOMER_SUCCESS = "customer_success"
+    CONSULTING = "consulting"
+    OTHER = "other"
+
+
+class JobType(str, Enum):
+    """Employment types."""
+
+    FULL_TIME = "full_time"
+    PART_TIME = "part_time"
+    CONTRACT = "contract"
+    INTERNSHIP = "internship"
+    TEMPORARY = "temporary"
+    FREELANCE = "freelance"
+
+
+class ExperienceLevel(str, Enum):
+    """Supported experience levels."""
+
+    ENTRY = "entry"
+    MID = "mid"
+    SENIOR = "senior"
+    LEAD = "lead"
+    DIRECTOR = "director"
+    EXECUTIVE = "executive"
+
+
+class WorkplaceType(str, Enum):
+    """Workplace environment types."""
+
+    ONSITE = "onsite"
+    REMOTE = "remote"
+    HYBRID = "hybrid"
+    UNKNOWN = "unknown"
+
+
+class JobCategorizationResult(BaseModel):
+    """Result of running the job categorizer."""
+
+    category: JobCategory = JobCategory.OTHER
+    confidence: float = 0.0
+    keyword_matches: Dict[str, int] = Field(default_factory=dict)
+    department_match: bool = False
+    reasoning: Optional[str] = None
+
+    model_config = ConfigDict(use_enum_values=False)
+
+
+class Job(BaseModel):
+    """Core job model used by the scraping pipeline."""
+
+    id: str
+    title: str
+    company: CompanyName
+    location: str
+    description: str
+    department: Optional[str] = None
+    category: JobCategory = JobCategory.OTHER
+    job_type: JobType = JobType.FULL_TIME
+    experience_level: ExperienceLevel = ExperienceLevel.MID
+    workplace_type: WorkplaceType = WorkplaceType.UNKNOWN
+    posted_date: Optional[datetime] = None
+    url: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(use_enum_values=False)
+
+
+__all__ = [
+    "CompanyName",
+    "JobCategory",
+    "JobType",
+    "ExperienceLevel",
+    "WorkplaceType",
+    "JobCategorizationResult",
+    "Job",
+]

--- a/scrapers/__init__.py
+++ b/scrapers/__init__.py
@@ -1,0 +1,5 @@
+"""Scraper package exposing the scraper factory."""
+
+from .scraper_factory import ScraperFactory
+
+__all__ = ["ScraperFactory"]

--- a/scrapers/scraper_factory.py
+++ b/scrapers/scraper_factory.py
@@ -1,0 +1,146 @@
+"""Utility for creating scraper instances from configuration."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Type, Union
+
+from .base_scraper import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+
+class ScraperFactory:
+    """Factory responsible for instantiating company scraper classes."""
+
+    def __init__(self, config_path: Optional[Union[str, Path]] = None) -> None:
+        """Load scraper configuration from the provided JSON file."""
+
+        self._config_path = Path(config_path) if config_path else self._default_config_path()
+
+        if not self._config_path.exists():
+            raise FileNotFoundError(f"Scraper configuration not found: {self._config_path}")
+
+        self._raw_config = self._load_config(self._config_path)
+        self._company_configs: Dict[str, Dict] = {
+            key.lower(): value for key, value in self._raw_config.get("companies", {}).items()
+        }
+        self._global_config: Dict = {
+            key: value for key, value in self._raw_config.items() if key != "companies"
+        }
+        self._registry: Dict[str, Type[BaseScraper]] = {}
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _default_config_path() -> Path:
+        """Return the default path to the company configuration file."""
+
+        return Path(__file__).resolve().parents[1] / "config" / "company_configs.json"
+
+    @staticmethod
+    def _load_config(path: Path) -> Dict:
+        """Load the JSON configuration file."""
+
+        with path.open("r", encoding="utf-8") as config_file:
+            return json.load(config_file)
+
+    # ------------------------------------------------------------------
+    # Registration and lookup utilities
+    # ------------------------------------------------------------------
+    def register_scraper(self, company_key: str, scraper_cls: Type[BaseScraper]) -> None:
+        """Register a scraper class for a given company key."""
+
+        if not issubclass(scraper_cls, BaseScraper):
+            raise TypeError("Scraper class must inherit from BaseScraper")
+
+        normalized_key = company_key.lower()
+
+        if normalized_key not in self._company_configs:
+            raise KeyError(f"Unknown company '{company_key}' in configuration")
+
+        self._registry[normalized_key] = scraper_cls
+        logger.debug("Registered scraper %s for company %s", scraper_cls.__name__, normalized_key)
+
+    def registered_companies(self) -> Iterable[str]:
+        """Return an iterable of currently registered company keys."""
+
+        return self._registry.keys()
+
+    def available_companies(self, include_disabled: bool = False) -> Iterable[str]:
+        """Return an iterable of company keys available in the configuration."""
+
+        for key, config in self._company_configs.items():
+            if include_disabled or config.get("enabled", True):
+                yield key
+
+    def get_company_config(self, company_key: str) -> Dict:
+        """Retrieve a deep copy of the configuration for a company."""
+
+        normalized_key = company_key.lower()
+
+        if normalized_key not in self._company_configs:
+            raise KeyError(f"No configuration found for company '{company_key}'")
+
+        return copy.deepcopy(self._company_configs[normalized_key])
+
+    # ------------------------------------------------------------------
+    # Factory logic
+    # ------------------------------------------------------------------
+    def create_scraper(self, company_key: str) -> BaseScraper:
+        """Instantiate the scraper associated with the provided company."""
+
+        normalized_key = company_key.lower()
+
+        company_config = self.get_company_config(normalized_key)
+
+        if not company_config.get("enabled", True):
+            raise ValueError(f"Scraper for company '{company_key}' is disabled in configuration")
+
+        scraper_cls = self._get_scraper_class(normalized_key, company_config)
+
+        return scraper_cls(company_config=company_config, global_config=copy.deepcopy(self._global_config))
+
+    def _get_scraper_class(self, company_key: str, company_config: Dict) -> Type[BaseScraper]:
+        """Resolve the scraper class for the given company."""
+
+        if company_key in self._registry:
+            return self._registry[company_key]
+
+        class_name = company_config.get("scraper_class")
+
+        if not class_name:
+            raise ValueError(f"Scraper class not specified for company '{company_key}'")
+
+        module_path = company_config.get("module", f"scrapers.companies.{company_key}_scraper")
+
+        try:
+            module = importlib.import_module(module_path)
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                f"Unable to import module '{module_path}' for company '{company_key}'"
+            ) from exc
+
+        try:
+            scraper_cls = getattr(module, class_name)
+        except AttributeError as exc:
+            raise AttributeError(
+                f"Module '{module_path}' does not define scraper class '{class_name}'"
+            ) from exc
+
+        if not issubclass(scraper_cls, BaseScraper):
+            raise TypeError(
+                f"Scraper class '{class_name}' for company '{company_key}' must inherit from BaseScraper"
+            )
+
+        self._registry[company_key] = scraper_cls
+        logger.debug("Dynamically loaded scraper %s for company %s", class_name, company_key)
+        return scraper_cls
+
+
+__all__ = ["ScraperFactory"]

--- a/tests/test_scraper_factory.py
+++ b/tests/test_scraper_factory.py
@@ -1,0 +1,218 @@
+"""Tests for the scraper factory implementation."""
+
+from typing import Dict, List
+import sys
+import types
+
+import pytest
+
+
+def _install_pydantic_stub() -> None:
+    """Install a minimal pydantic stub when the package is unavailable."""
+
+    if "pydantic" in sys.modules:
+        return
+
+    stub = types.ModuleType("pydantic")
+
+    from dataclasses import dataclass, field as dataclass_field
+
+    class ConfigDict(dict):
+        def __init__(self, **kwargs):  # pragma: no cover - trivial initializer
+            super().__init__(**kwargs)
+
+    def Field(*, default=None, default_factory=None):  # pragma: no cover - simple helper
+        if default_factory is not None:
+            return dataclass_field(default_factory=default_factory)
+        if default is not None:
+            return dataclass_field(default=default)
+        return dataclass_field()
+
+    class _BaseModelMeta(type):
+        def __new__(mcls, name, bases, namespace):  # pragma: no cover - simple meta
+            cls = super().__new__(mcls, name, bases, dict(namespace))
+            return dataclass(cls)
+
+    class BaseModel(metaclass=_BaseModelMeta):
+        pass
+
+    stub.BaseModel = BaseModel
+    stub.ConfigDict = ConfigDict
+    stub.Field = Field
+
+    sys.modules.setdefault("pydantic", stub)
+
+
+_install_pydantic_stub()
+
+
+def _install_selenium_stubs() -> None:
+    """Install lightweight Selenium stubs so imports succeed during testing."""
+
+    selenium_module = types.ModuleType("selenium")
+
+    # webdriver module and dependencies
+    webdriver_module = types.ModuleType("selenium.webdriver")
+    webdriver_module.Remote = type("Remote", (), {})
+    selenium_module.webdriver = webdriver_module
+
+    webdriver_common = types.ModuleType("selenium.webdriver.common")
+    webdriver_common_by = types.ModuleType("selenium.webdriver.common.by")
+    webdriver_common_by.By = type("By", (), {})
+
+    webdriver_support = types.ModuleType("selenium.webdriver.support")
+    webdriver_support_ui = types.ModuleType("selenium.webdriver.support.ui")
+    webdriver_support_ui.WebDriverWait = type("WebDriverWait", (), {})
+    webdriver_support_ec = types.ModuleType("selenium.webdriver.support.expected_conditions")
+
+    webdriver_chrome_options = types.ModuleType("selenium.webdriver.chrome.options")
+    webdriver_chrome_options.Options = type("Options", (), {})
+
+    webdriver_firefox_options = types.ModuleType("selenium.webdriver.firefox.options")
+    webdriver_firefox_options.Options = type("Options", (), {})
+
+    selenium_common = types.ModuleType("selenium.common")
+    selenium_common_exceptions = types.ModuleType("selenium.common.exceptions")
+    selenium_common_exceptions.TimeoutException = type("TimeoutException", (Exception,), {})
+    selenium_common_exceptions.WebDriverException = type("WebDriverException", (Exception,), {})
+
+    modules: Dict[str, types.ModuleType] = {
+        "selenium": selenium_module,
+        "selenium.webdriver": webdriver_module,
+        "selenium.webdriver.common": webdriver_common,
+        "selenium.webdriver.common.by": webdriver_common_by,
+        "selenium.webdriver.support": webdriver_support,
+        "selenium.webdriver.support.ui": webdriver_support_ui,
+        "selenium.webdriver.support.expected_conditions": webdriver_support_ec,
+        "selenium.webdriver.chrome": types.ModuleType("selenium.webdriver.chrome"),
+        "selenium.webdriver.chrome.options": webdriver_chrome_options,
+        "selenium.webdriver.firefox": types.ModuleType("selenium.webdriver.firefox"),
+        "selenium.webdriver.firefox.options": webdriver_firefox_options,
+        "selenium.common": selenium_common,
+        "selenium.common.exceptions": selenium_common_exceptions,
+    }
+
+    for name, module in modules.items():
+        sys.modules.setdefault(name, module)
+
+
+def _install_webdriver_manager_stubs() -> None:
+    """Install webdriver-manager stubs used by the base scraper."""
+
+    class _ChromeDriverManager:
+        def install(self) -> str:  # pragma: no cover - trivial return
+            return "chromedriver"
+
+    class _GeckoDriverManager:
+        def install(self) -> str:  # pragma: no cover - trivial return
+            return "geckodriver"
+
+    chrome_module = types.ModuleType("webdriver_manager.chrome")
+    chrome_module.ChromeDriverManager = _ChromeDriverManager
+
+    firefox_module = types.ModuleType("webdriver_manager.firefox")
+    firefox_module.GeckoDriverManager = _GeckoDriverManager
+
+    sys.modules.setdefault("webdriver_manager", types.ModuleType("webdriver_manager"))
+    sys.modules.setdefault("webdriver_manager.chrome", chrome_module)
+    sys.modules.setdefault("webdriver_manager.firefox", firefox_module)
+
+
+_install_selenium_stubs()
+_install_webdriver_manager_stubs()
+
+
+def _install_settings_stub() -> None:
+    """Provide a lightweight settings module used by the base scraper."""
+
+    config_package = sys.modules.setdefault("config", types.ModuleType("config"))
+    settings_module = types.ModuleType("config.settings")
+
+    class _BrowserSettings:
+        browser_timeout = 30
+        browser_type = "chrome"
+        browser_headless = True
+        browser_window_size = "1920x1080"
+        webdriver_path = "auto"
+        chrome_binary_path = None
+        firefox_binary_path = None
+
+    class _ScrapingSettings:
+        user_agent = "test-agent"
+
+    class _Settings:
+        def __init__(self) -> None:
+            self.browser = _BrowserSettings()
+            self.scraping = _ScrapingSettings()
+
+    def get_settings() -> _Settings:  # pragma: no cover - simple factory
+        return _Settings()
+
+    settings_module.get_settings = get_settings
+    config_package.settings = settings_module
+    sys.modules["config.settings"] = settings_module
+
+
+_install_settings_stub()
+
+from scrapers import ScraperFactory  # noqa: E402  pylint: disable=wrong-import-position
+from scrapers.base_scraper import BaseScraper  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class DummyScraper(BaseScraper):
+    """Minimal scraper implementation used for testing."""
+
+    async def _extract_job_listings(self) -> List[Dict]:
+        return []
+
+    async def scrape_jobs(self) -> List:  # type: ignore[override]
+        # Override to avoid interacting with Selenium during tests
+        return []
+
+
+@pytest.fixture()
+def factory() -> ScraperFactory:
+    return ScraperFactory()
+
+
+def test_available_companies(factory: ScraperFactory) -> None:
+    companies = set(factory.available_companies())
+    assert {"meta", "amazon", "apple", "netflix", "google"}.issubset(companies)
+
+
+def test_register_and_create_scraper(factory: ScraperFactory) -> None:
+    factory.register_scraper("meta", DummyScraper)
+
+    scraper = factory.create_scraper("meta")
+
+    assert isinstance(scraper, DummyScraper)
+    assert scraper.company_config["name"].lower() == "meta"
+    assert "categorization_rules" in scraper.global_config
+
+
+def test_disabled_scraper_raises(factory: ScraperFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    original_get_company_config = factory.get_company_config
+
+    def disable_meta(_: str) -> Dict:
+        config = original_get_company_config("meta")
+        config["enabled"] = False
+        return config
+
+    monkeypatch.setattr(factory, "get_company_config", disable_meta)
+
+    with pytest.raises(ValueError):
+        factory.create_scraper("meta")
+
+
+def test_missing_scraper_class_raises(factory: ScraperFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    original_get_company_config = factory.get_company_config
+
+    def config_without_class(_: str) -> Dict:
+        config = original_get_company_config("meta")
+        config.pop("scraper_class", None)
+        return config
+
+    monkeypatch.setattr(factory, "get_company_config", config_without_class)
+
+    with pytest.raises(ValueError):
+        factory.create_scraper("meta")


### PR DESCRIPTION
## Summary
- replace dataclass-based job models with Pydantic BaseModel implementations while preserving enums
- add a lightweight Pydantic stub to the scraper factory tests so they run in minimal environments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d90bbc79c08321b1c98ad50157060f